### PR TITLE
Add dev endpoint to seed successful payment data

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,19 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Development helpers
+
+### Seed a successful purchase
+
+To quickly work on the post-payment experience you can create a fake successful purchase in Supabase by calling the local API route `POST /api/dev/seed-success`. The route is disabled in production and uses your `SUPABASE_SERVICE_ROLE_KEY`, so ensure the environment variables from `.env.local` are available when running the development server.
+
+The endpoint accepts optional overrides for `email`, `user`, `amount`, and `token`. When no payload is provided it will create a paid record for `mail@ahmadarib.com` and issue a fresh token.
+
+```bash
+curl -X POST http://localhost:3000/api/dev/seed-success \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"mail@ahmadarib.com","user":"ahmadarib"}'
+```
+
+The JSON response includes the generated token so you can log in immediately via `/login` and continue building the test pages.

--- a/src/app/api/dev/seed-success/route.ts
+++ b/src/app/api/dev/seed-success/route.ts
@@ -1,0 +1,111 @@
+import { NextResponse } from 'next/server';
+import { supabaseAdmin } from '@/lib/supabaseAdmin';
+import { addDays, generateToken } from '@/lib/token';
+
+export const runtime = 'nodejs';
+
+export async function POST(req: Request) {
+  if (process.env.NODE_ENV === 'production') {
+    return NextResponse.json({ error: 'Not available in production' }, { status: 403 });
+  }
+
+  const body = (await req.json().catch(() => ({}))) as Partial<{
+    email: string;
+    user: string;
+    amount: number;
+    token: string;
+  }>;
+
+  const email = body.email?.trim() || 'mail@ahmadarib.com';
+  const user = body.user?.trim() || 'ahmadarib';
+  const amount = typeof body.amount === 'number' ? body.amount : 0;
+  const token = body.token?.trim() || generateToken(18);
+  const expiresAt = addDays(14).toISOString();
+  const externalId = `dev-${Date.now()}`;
+
+  const paymentPayload = {
+    seeded: true,
+    user,
+    email,
+    source: 'manual-dev-seed',
+    createdAt: new Date().toISOString(),
+  };
+
+  const { error: paymentError } = await supabaseAdmin.from('payments').insert({
+    provider: 'manual_dev',
+    external_id: externalId,
+    email,
+    amount,
+    status: 'PAID',
+    payload: paymentPayload,
+  });
+
+  if (paymentError) {
+    console.error('Seed payment insert error', paymentError);
+    return NextResponse.json(
+      { error: 'Failed to create payment record', details: paymentError.message },
+      { status: 500 },
+    );
+  }
+
+  let userId: string | null = null;
+
+  const { data: existingUser, error: existingError } = await supabaseAdmin
+    .from('users')
+    .select('id')
+    .eq('email', email)
+    .maybeSingle();
+
+  if (existingError) {
+    console.error('Seed user lookup error', existingError);
+    return NextResponse.json(
+      { error: 'Failed to fetch user', details: existingError.message },
+      { status: 500 },
+    );
+  }
+
+  if (existingUser?.id) {
+    userId = existingUser.id;
+  } else {
+    const { data: insertedUser, error: insertUserError } = await supabaseAdmin
+      .from('users')
+      .insert({ email })
+      .select('id')
+      .single();
+
+    if (insertUserError) {
+      console.error('Seed user insert error', insertUserError);
+      return NextResponse.json(
+        { error: 'Failed to create user', details: insertUserError.message },
+        { status: 500 },
+      );
+    }
+
+    userId = insertedUser?.id ?? null;
+  }
+
+  const { error: tokenError } = await supabaseAdmin.from('tokens').insert({
+    user_id: userId,
+    token,
+    expires_at: expiresAt,
+    is_active: true,
+  });
+
+  if (tokenError) {
+    console.error('Seed token insert error', tokenError);
+    return NextResponse.json(
+      { error: 'Failed to create token', details: tokenError.message },
+      { status: 500 },
+    );
+  }
+
+  return NextResponse.json({
+    ok: true,
+    email,
+    user,
+    token,
+    expiresAt,
+    externalId,
+    userId,
+  });
+}


### PR DESCRIPTION
## Summary
- add a development-only API endpoint that mirrors the payment success flow by inserting payment, user, and token rows for testing
- document how to call the helper endpoint to obtain a fresh login token during local development

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ca86ab542c832eabdb110325ad14af