### PR TITLE
Add timed section flow and load Supabase env from .env.local

### DIFF
--- a/src/app/api/session/route.ts
+++ b/src/app/api/session/route.ts
@@ -1,9 +1,14 @@
 import { NextResponse } from 'next/server';
-import { supabaseAdmin } from '@/lib/supabaseAdmin';
+import { getSupabaseAdmin } from '@/lib/supabaseAdmin';
 
 export async function POST(req: Request) {
+  const supabase = getSupabaseAdmin();
+  if (!supabase) {
+    return NextResponse.json({ error: 'Supabase is not configured' }, { status: 503 });
+  }
+
   const { token } = await req.json();
-  const { data } = await supabaseAdmin.from('tokens').select('*').eq('token', token).eq('is_active', true).single();
+  const { data } = await supabase.from('tokens').select('*').eq('token', token).eq('is_active', true).single();
 
   if (!data) return NextResponse.json({ error: 'Invalid or expired token' }, { status: 401 });
   if (new Date(data.expires_at) < new Date()) return NextResponse.json({ error: 'Token expired' }, { status: 401 });

--- a/src/app/api/tests/[testId]/assets/[...assetPath]/route.ts
+++ b/src/app/api/tests/[testId]/assets/[...assetPath]/route.ts
@@ -35,9 +35,9 @@ function getMimeType(ext: string): string {
 
 export async function GET(
   _request: Request,
-  { params }: { params: { testId: string; assetPath: string[] } }
+  context: { params: Promise<{ testId: string; assetPath: string[] }> }
 ): Promise<Response> {
-  const { testId, assetPath } = params;
+  const { testId, assetPath } = await context.params;
   if (!isSafeTestId(testId) || !Array.isArray(assetPath) || assetPath.length === 0) {
     return new Response('Not found', { status: 404 });
   }

--- a/src/components/test/TestRunner.tsx
+++ b/src/components/test/TestRunner.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Image from 'next/image';
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import type {
   ListeningSectionDefinition,
@@ -17,29 +17,15 @@ type AnswerValue = string | number | null;
 
 type AnswersState = Record<string, AnswerValue>;
 
-type QuestionFeedback = {
-  score: number;
-  maxScore: number;
-  isCorrect: boolean;
-  correctAnswer: unknown;
-};
-
-type SubmissionResult = {
-  testId: string;
+type SubmissionInfo = {
   submissionId: string | null;
-  totalScore: number;
-  maxScore: number;
-  answered: number;
-  questionCount: number;
   warnings: string[];
-  perQuestion: Record<string, QuestionFeedback>;
 };
 
 type SectionProps = {
   section: SectionDefinition;
   answers: AnswersState;
   onChange: (qId: string, value: AnswerValue) => void;
-  feedback: Record<string, QuestionFeedback> | undefined;
   audioControls?: { allowSeek?: boolean; showRemaining?: boolean };
 };
 
@@ -47,7 +33,6 @@ type QuestionCardProps = {
   question: NormalizedQuestion;
   value: AnswerValue;
   onChange: (value: AnswerValue) => void;
-  feedback?: QuestionFeedback;
 };
 
 type AudioPlayerProps = {
@@ -55,16 +40,29 @@ type AudioPlayerProps = {
   allowSeek?: boolean;
   showRemaining?: boolean;
 };
+function resolveMinutes(value: number | undefined, fallback: number): number {
+  if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
+    return value;
+  }
+  return fallback;
+}
 
-function formatMinutes(minutes?: number): string | null {
+function formatSectionMinutes(minutes?: number): string | null {
   if (typeof minutes !== 'number' || Number.isNaN(minutes)) return null;
   if (minutes <= 0) return null;
   return `${minutes} minutes`;
 }
 
-function formatPercentage(total: number, max: number): string {
-  if (!max) return '0%';
-  return `${Math.round((total / max) * 1000) / 10}%`;
+function formatDuration(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds <= 0) return '00:00';
+  const safeSeconds = Math.max(0, Math.floor(seconds));
+  const minutes = Math.floor(safeSeconds / 60)
+    .toString()
+    .padStart(2, '0');
+  const secs = Math.floor(safeSeconds % 60)
+    .toString()
+    .padStart(2, '0');
+  return `${minutes}:${secs}`;
 }
 
 function AssetDisplay({ assets, sectionTitle }: { assets?: Record<string, string>; sectionTitle: string }) {
@@ -175,35 +173,13 @@ function AudioPlayer({ src, allowSeek = true, showRemaining }: AudioPlayerProps)
   );
 }
 
-function QuestionCard({ question, value, onChange, feedback }: QuestionCardProps) {
+function QuestionCard({ question, value, onChange }: QuestionCardProps) {
   const helperList = useMemo(() => {
     if (question.qType === 'map_labeling') return question.optionsLetters;
     if (question.qType === 'paragraph_match') return question.optionsParagraphs;
     if (question.qType === 'match_list') return question.optionsLabels;
     return undefined;
   }, [question]);
-
-  const renderCorrectAnswer = () => {
-    if (!feedback || feedback.isCorrect) return null;
-    const { correctAnswer } = feedback;
-    if (correctAnswer === null || typeof correctAnswer === 'undefined') return null;
-
-    if (Array.isArray(correctAnswer)) {
-      if (correctAnswer.length === 0) return null;
-      return correctAnswer.join(', ');
-    }
-
-    if (typeof correctAnswer === 'number' && question.qType === 'mcq_single') {
-      const options = question.options ?? [];
-      const optionText = options[correctAnswer];
-      if (optionText) return optionText;
-      return `Option ${correctAnswer + 1}`;
-    }
-
-    return String(correctAnswer);
-  };
-
-  const correctAnswerDisplay = renderCorrectAnswer();
 
   let inputControl: JSX.Element | null = null;
 
@@ -229,7 +205,7 @@ function QuestionCard({ question, value, onChange, feedback }: QuestionCardProps
                   onChange={() => onChange(idx)}
                   className="mt-1 h-4 w-4"
                 />
-                <span className="text-sm text-slate-700">
+                <span className="text-sm text-slate-800">
                   <span className="font-semibold">{option}</span>
                 </span>
               </label>
@@ -256,7 +232,7 @@ function QuestionCard({ question, value, onChange, feedback }: QuestionCardProps
                   onChange={() => onChange(option)}
                   className="h-4 w-4"
                 />
-                <span className="text-sm font-medium text-slate-700">{option}</span>
+                <span className="text-sm font-medium text-slate-800">{option}</span>
               </label>
             );
           })}
@@ -272,7 +248,7 @@ function QuestionCard({ question, value, onChange, feedback }: QuestionCardProps
         <select
           value={typeof value === 'string' ? value : ''}
           onChange={(event) => onChange(event.target.value || null)}
-          className="w-full rounded-lg border bg-white px-3 py-2 text-sm outline-none focus:border-sky-500 focus:ring-2 focus:ring-sky-200"
+          className="w-full rounded-lg border bg-white px-3 py-2 text-sm text-slate-900 outline-none focus:border-sky-500 focus:ring-2 focus:ring-sky-200"
         >
           <option value="">Select an option</option>
           {options.map((option) => (
@@ -291,21 +267,11 @@ function QuestionCard({ question, value, onChange, feedback }: QuestionCardProps
           value={typeof value === 'string' ? value : ''}
           onChange={(event) => onChange(event.target.value)}
           placeholder="Type your answer"
-          className="w-full rounded-lg border px-3 py-2 text-sm outline-none transition focus:border-sky-500 focus:ring-2 focus:ring-sky-200"
+          className="w-full rounded-lg border px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-sky-500 focus:ring-2 focus:ring-sky-200"
         />
       );
     }
   }
-
-  const badge = feedback ? (
-    <span
-      className={`inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold ${
-        feedback.isCorrect ? 'bg-emerald-100 text-emerald-700' : 'bg-amber-100 text-amber-700'
-      }`}
-    >
-      {feedback.isCorrect ? 'Correct' : `Score ${feedback.score}/${feedback.maxScore}`}
-    </span>
-  ) : null;
 
   return (
     <div className="space-y-3 rounded-xl border px-4 py-4 shadow-sm">
@@ -314,22 +280,16 @@ function QuestionCard({ question, value, onChange, feedback }: QuestionCardProps
           <p className="text-xs font-semibold uppercase tracking-wide text-sky-600">{question.qId}</p>
           <MarkdownText content={question.promptMd} className="mt-1 space-y-1 text-sm text-slate-700" />
         </div>
-        {badge}
       </div>
       {helperList && helperList.length > 0 && (
         <p className="text-xs text-slate-500">Choices: {helperList.join(', ')}</p>
       )}
       <div>{inputControl}</div>
-      {correctAnswerDisplay && (
-        <p className="text-xs text-slate-500">
-          Correct answer: <span className="font-semibold">{correctAnswerDisplay}</span>
-        </p>
-      )}
     </div>
   );
 }
 
-function ListeningSectionView({ section, answers, onChange, feedback, audioControls }: SectionProps & { section: ListeningSectionDefinition }) {
+function ListeningSectionView({ section, answers, onChange, audioControls }: SectionProps & { section: ListeningSectionDefinition }) {
   return (
     <div className="space-y-6">
       <MarkdownText content={section.instructionsMd} className="space-y-3 text-sm text-slate-600" />
@@ -346,7 +306,6 @@ function ListeningSectionView({ section, answers, onChange, feedback, audioContr
             question={question}
             value={answers[question.qId] ?? null}
             onChange={(value) => onChange(question.qId, value)}
-            feedback={feedback?.[question.qId]}
           />
         ))}
       </div>
@@ -354,7 +313,7 @@ function ListeningSectionView({ section, answers, onChange, feedback, audioContr
   );
 }
 
-function ReadingSectionView({ section, answers, onChange, feedback }: SectionProps & { section: ReadingSectionDefinition }) {
+function ReadingSectionView({ section, answers, onChange }: SectionProps & { section: ReadingSectionDefinition }) {
   return (
     <div className="space-y-6">
       <MarkdownText content={section.instructionsMd} className="space-y-3 text-sm text-slate-600" />
@@ -373,7 +332,6 @@ function ReadingSectionView({ section, answers, onChange, feedback }: SectionPro
               question={question}
               value={answers[question.qId] ?? null}
               onChange={(value) => onChange(question.qId, value)}
-              feedback={feedback?.[question.qId]}
             />
           ))}
         </div>
@@ -381,53 +339,192 @@ function ReadingSectionView({ section, answers, onChange, feedback }: SectionPro
     </div>
   );
 }
-
 export function TestRunner({ test }: { test: TestDefinition }) {
+  const listeningSections = useMemo(
+    () => test.sections.filter((section): section is ListeningSectionDefinition => section.type === 'listening'),
+    [test.sections]
+  );
+  const readingSections = useMemo(
+    () => test.sections.filter((section): section is ReadingSectionDefinition => section.type === 'reading'),
+    [test.sections]
+  );
+
+  const hasListening = listeningSections.length > 0;
+  const hasReading = readingSections.length > 0;
+
+  const listeningMinutes = resolveMinutes(test.timing?.listeningTotalMinutes, 30);
+  const readingMinutes = resolveMinutes(test.timing?.readingTotalMinutes, 60);
+  const listeningTotalSeconds = Math.floor(listeningMinutes * 60);
+  const readingTotalSeconds = Math.floor(readingMinutes * 60);
+
   const [answers, setAnswers] = useState<AnswersState>({});
-  const [result, setResult] = useState<SubmissionResult | null>(null);
+  const [phase, setPhase] = useState<'listening' | 'reading'>(hasListening ? 'listening' : 'reading');
+  const [listeningTimeLeft, setListeningTimeLeft] = useState(listeningTotalSeconds);
+  const [readingTimeLeft, setReadingTimeLeft] = useState(readingTotalSeconds);
+  const [listeningComplete, setListeningComplete] = useState(!hasListening);
+  const [readingComplete, setReadingComplete] = useState(!hasReading);
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
+  const [submissionInfo, setSubmissionInfo] = useState<SubmissionInfo | null>(null);
+  const [showThankYou, setShowThankYou] = useState(false);
 
   const audioControls = test.uiConstraints?.audioControls;
+
+  const listeningCompletedRef = useRef(listeningComplete);
+  const readingCompletedRef = useRef(readingComplete);
+  const submittingRef = useRef(false);
+
+  useEffect(() => {
+    setAnswers({});
+    setPhase(hasListening ? 'listening' : 'reading');
+    setListeningTimeLeft(listeningTotalSeconds);
+    setReadingTimeLeft(readingTotalSeconds);
+    setListeningComplete(!hasListening);
+    setReadingComplete(!hasReading);
+    listeningCompletedRef.current = !hasListening;
+    readingCompletedRef.current = !hasReading;
+    setError(null);
+    setSubmissionInfo(null);
+    setShowThankYou(false);
+    setSubmitting(false);
+    submittingRef.current = false;
+  }, [
+    test.testId,
+    hasListening,
+    hasReading,
+    listeningTotalSeconds,
+    readingTotalSeconds,
+  ]);
 
   const handleChange = useCallback((qId: string, value: AnswerValue) => {
     setAnswers((prev) => ({ ...prev, [qId]: value }));
   }, []);
 
-  const sectionFeedback = useMemo(() => result?.perQuestion ?? {}, [result]);
-
   const submitAnswers = useCallback(async () => {
+    if (submittingRef.current) return false;
+    submittingRef.current = true;
     setSubmitting(true);
     setError(null);
+
     try {
       const response = await fetch(`/api/tests/${test.testId}/submit`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ answers }),
       });
-      const data = (await response.json().catch(() => ({}))) as Partial<SubmissionResult> & { error?: string };
-      if (!response.ok || !data || typeof data.totalScore !== 'number') {
+      const data = (await response.json().catch(() => ({}))) as Partial<SubmissionInfo> & { warnings?: unknown; error?: string };
+
+      if (!response.ok) {
         throw new Error(data?.error ?? 'Unable to submit answers right now.');
       }
-      setResult({
-        testId: test.testId,
-        submissionId: data.submissionId ?? null,
-        totalScore: data.totalScore,
-        maxScore: data.maxScore ?? 0,
-        answered: data.answered ?? 0,
-        questionCount: data.questionCount ?? 0,
-        warnings: Array.isArray(data.warnings) ? data.warnings : [],
-        perQuestion: data.perQuestion ?? {},
-      });
+
+      const warnings = Array.isArray(data?.warnings)
+        ? data.warnings.filter((warning): warning is string => typeof warning === 'string')
+        : [];
+      const submissionId = typeof data?.submissionId === 'string' ? data.submissionId : null;
+
+      setSubmissionInfo({ submissionId, warnings });
+      setShowThankYou(true);
+      setReadingComplete(true);
+      setListeningComplete(true);
+      return true;
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Unexpected error during submission.');
+      return false;
     } finally {
+      submittingRef.current = false;
       setSubmitting(false);
     }
   }, [answers, test.testId]);
 
-  const listeningTime = formatMinutes(test.timing?.listeningTotalMinutes);
-  const readingTime = formatMinutes(test.timing?.readingTotalMinutes);
+  const handlePhaseComplete = useCallback(
+    (completed: 'listening' | 'reading') => {
+      if (completed === 'listening') {
+        listeningCompletedRef.current = true;
+        setListeningComplete(true);
+        if (hasReading) {
+          setPhase('reading');
+        } else {
+          readingCompletedRef.current = true;
+          void submitAnswers();
+        }
+      } else {
+        readingCompletedRef.current = true;
+        void submitAnswers();
+      }
+    },
+    [hasReading, submitAnswers]
+  );
+
+  useEffect(() => {
+    if (showThankYou) return;
+    if (phase !== 'listening') return;
+    if (listeningCompletedRef.current) return;
+
+    const timer = setInterval(() => {
+      setListeningTimeLeft((prev) => {
+        if (prev <= 1) {
+          clearInterval(timer);
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+
+    return () => clearInterval(timer);
+  }, [phase, showThankYou]);
+
+  useEffect(() => {
+    if (showThankYou) return;
+    if (phase === 'listening' && listeningTimeLeft <= 0 && !listeningCompletedRef.current) {
+      handlePhaseComplete('listening');
+    }
+  }, [phase, listeningTimeLeft, showThankYou, handlePhaseComplete]);
+
+  useEffect(() => {
+    if (showThankYou) return;
+    if (phase !== 'reading') return;
+    if (readingCompletedRef.current) return;
+
+    const timer = setInterval(() => {
+      setReadingTimeLeft((prev) => {
+        if (prev <= 1) {
+          clearInterval(timer);
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+
+    return () => clearInterval(timer);
+  }, [phase, showThankYou]);
+
+  useEffect(() => {
+    if (showThankYou) return;
+    if (phase === 'reading' && readingTimeLeft <= 0 && !readingCompletedRef.current) {
+      handlePhaseComplete('reading');
+    }
+  }, [phase, readingTimeLeft, showThankYou, handlePhaseComplete]);
+
+  const visibleSections = phase === 'listening' ? listeningSections : readingSections;
+  const listeningDurationLabel = formatSectionMinutes(listeningMinutes);
+  const readingDurationLabel = formatSectionMinutes(readingMinutes);
+
+  const actionLabel = phase === 'listening' ? (hasReading ? 'Proceed to reading' : 'Submit test') : 'Submit test';
+  const actionHandler = phase === 'listening' ? () => handlePhaseComplete('listening') : () => handlePhaseComplete('reading');
+
+  if (!hasListening && !hasReading) {
+    return (
+      <div className="min-h-screen bg-slate-100 py-12">
+        <div className="mx-auto max-w-4xl px-6">
+          <div className="rounded-3xl border border-slate-200 bg-white p-8 text-center shadow-lg">
+            <h1 className="text-2xl font-semibold text-slate-900">No sections available for this test.</h1>
+            <p className="mt-3 text-sm text-slate-600">Please contact the administrator for assistance.</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="min-h-screen bg-slate-100 py-12">
@@ -435,107 +532,127 @@ export function TestRunner({ test }: { test: TestDefinition }) {
         <header className="rounded-3xl bg-gradient-to-br from-sky-900 via-indigo-900 to-slate-900 p-10 text-white shadow-xl">
           <p className="text-xs uppercase tracking-[0.3em] text-sky-200">IELTS Mock Test</p>
           <h1 className="mt-2 text-3xl font-bold sm:text-4xl">{test.title}</h1>
-          <div className="mt-4 flex flex-wrap items-center gap-3 text-sm text-sky-100">
-            <span className="inline-flex items-center gap-2 rounded-full bg-white/10 px-4 py-1">
-              <span className="h-2 w-2 rounded-full bg-emerald-300" />
-              Test ID: {test.testId}
-            </span>
-            {listeningTime && (
-              <span className="inline-flex items-center gap-2 rounded-full bg-white/10 px-4 py-1">
-                <span className="h-2 w-2 rounded-full bg-amber-300" />
-                Listening ~ {listeningTime}
-              </span>
-            )}
-            {readingTime && (
-              <span className="inline-flex items-center gap-2 rounded-full bg-white/10 px-4 py-1">
-                <span className="h-2 w-2 rounded-full bg-sky-300" />
-                Reading ~ {readingTime}
-              </span>
-            )}
+          <div className="mt-6 grid gap-4 sm:grid-cols-2">
+            <div
+              className={`rounded-2xl border p-5 ${
+                !showThankYou && phase === 'listening'
+                  ? 'border-white bg-white text-slate-900 shadow-lg'
+                  : 'border-white/20 bg-white/10 text-sky-100'
+              }`}
+            >
+              <p className="text-xs uppercase tracking-wide">Listening</p>
+              <p className="mt-2 text-2xl font-semibold">{formatDuration(listeningTimeLeft)}</p>
+              <p className="mt-1 text-sm text-sky-200/80">Time remaining</p>
+              {listeningDurationLabel && (
+                <p className="mt-3 text-xs text-sky-200/70">Planned duration: {listeningDurationLabel}</p>
+              )}
+              {listeningComplete && (
+                <p className="mt-3 text-xs font-semibold text-emerald-200">Completed</p>
+              )}
+            </div>
+            <div
+              className={`rounded-2xl border p-5 ${
+                !showThankYou && phase === 'reading'
+                  ? 'border-white bg-white text-slate-900 shadow-lg'
+                  : 'border-white/20 bg-white/10 text-sky-100'
+              }`}
+            >
+              <p className="text-xs uppercase tracking-wide">Reading</p>
+              <p className="mt-2 text-2xl font-semibold">{formatDuration(readingTimeLeft)}</p>
+              <p className="mt-1 text-sm text-sky-200/80">Time remaining</p>
+              {readingDurationLabel && (
+                <p className="mt-3 text-xs text-sky-200/70">Planned duration: {readingDurationLabel}</p>
+              )}
+              {readingComplete && (
+                <p className="mt-3 text-xs font-semibold text-emerald-200">Completed</p>
+              )}
+            </div>
           </div>
-          {result && (
-            <div className="mt-6 grid gap-4 rounded-2xl border border-white/20 bg-white/10 p-6 text-sm text-sky-50 sm:grid-cols-3">
-              <div>
-                <p className="text-xs uppercase tracking-wide text-sky-200">Overall score</p>
-                <p className="mt-1 text-2xl font-semibold">
-                  {result.totalScore} / {result.maxScore}
-                </p>
-              </div>
-              <div>
-                <p className="text-xs uppercase tracking-wide text-sky-200">Percentage</p>
-                <p className="mt-1 text-2xl font-semibold">{formatPercentage(result.totalScore, result.maxScore)}</p>
-              </div>
-              <div>
-                <p className="text-xs uppercase tracking-wide text-sky-200">Answered</p>
-                <p className="mt-1 text-2xl font-semibold">
-                  {result.answered} / {result.questionCount}
-                </p>
-              </div>
+          {!showThankYou && (
+            <p className="mt-6 text-sm text-sky-100">
+              You are currently working on the {phase === 'listening' ? 'Listening' : 'Reading'} section.
+              Time will automatically {phase === 'listening' ? 'move you to Reading' : 'submit the test'} when it expires.
+            </p>
+          )}
+          {showThankYou && (
+            <div className="mt-6 rounded-2xl border border-white/20 bg-white/10 p-6 text-sm text-sky-50">
+              Thank you for completing the test. We will send your results to your email shortly.
             </div>
           )}
         </header>
 
-        {result?.warnings?.length ? (
-          <div className="rounded-2xl border border-amber-200 bg-amber-50 p-6 text-sm text-amber-700 shadow-sm">
-            <h2 className="text-base font-semibold">Submission notes</h2>
-            <ul className="mt-3 space-y-2 list-disc pl-5">
-              {result.warnings.map((warning) => (
-                <li key={warning}>{warning}</li>
-              ))}
-            </ul>
-          </div>
-        ) : null}
-
-        {test.sections.map((section) => (
-          <section key={section.sectionId} className="rounded-3xl border border-slate-200 bg-white shadow-lg">
-            <div className="border-b border-slate-200 px-6 py-6">
-              <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
-                {section.type === 'listening' ? 'Listening' : 'Reading'}
+        {showThankYou ? (
+          <div className="rounded-3xl border border-slate-200 bg-white p-8 shadow-lg">
+            <h2 className="text-2xl font-semibold text-slate-900">Thank you for your submission!</h2>
+            <p className="mt-3 text-sm text-slate-600">
+              Your answers have been recorded. Our team will review them and share the result via email.
+            </p>
+            {submissionInfo?.submissionId && (
+              <p className="mt-4 text-sm text-slate-600">
+                Confirmation ID: <span className="font-mono text-slate-900">{submissionInfo.submissionId}</span>
               </p>
-              <h2 className="mt-1 text-2xl font-semibold text-slate-900">{section.title}</h2>
-            </div>
-            <div className="px-6 py-6">
-              {section.type === 'listening' ? (
-                <ListeningSectionView
-                  section={section}
-                  answers={answers}
-                  onChange={handleChange}
-                  feedback={sectionFeedback}
-                  audioControls={audioControls}
-                />
-              ) : (
-                <ReadingSectionView
-                  section={section}
-                  answers={answers}
-                  onChange={handleChange}
-                  feedback={sectionFeedback}
-                />
-              )}
-            </div>
-          </section>
-        ))}
-
-        <div className="rounded-3xl border border-slate-200 bg-white px-6 py-6 shadow-lg">
-          {error && <p className="text-sm font-semibold text-red-600">{error}</p>}
-          {result && !error && (
-            <p className="text-sm text-slate-600">
-              Submission ID: <span className="font-mono">{result.submissionId ?? 'Not stored (local scoring only)'}</span>
-            </p>
-          )}
-          <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-            <p className="text-xs text-slate-500">
-              You can update your answers and resubmit as needed. Only the latest attempt is saved when Supabase is available.
-            </p>
-            <button
-              type="button"
-              onClick={submitAnswers}
-              disabled={submitting}
-              className="inline-flex items-center justify-center rounded-full bg-sky-600 px-6 py-3 text-sm font-semibold text-white shadow transition hover:bg-sky-500 disabled:cursor-not-allowed disabled:opacity-60"
-            >
-              {submitting ? 'Submitting…' : 'Submit answers'}
-            </button>
+            )}
+            {submissionInfo?.warnings?.length ? (
+              <div className="mt-6 rounded-2xl border border-amber-200 bg-amber-50 p-6 text-sm text-amber-700 shadow-sm">
+                <h3 className="text-base font-semibold">Submission notes</h3>
+                <ul className="mt-3 space-y-2 list-disc pl-5">
+                  {submissionInfo.warnings.map((warning) => (
+                    <li key={warning}>{warning}</li>
+                  ))}
+                </ul>
+              </div>
+            ) : null}
           </div>
-        </div>
+        ) : (
+          <>
+            {visibleSections.map((section) => (
+              <section key={section.sectionId} className="rounded-3xl border border-slate-200 bg-white shadow-lg">
+                <div className="border-b border-slate-200 px-6 py-6">
+                  <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                    {section.type === 'listening' ? 'Listening' : 'Reading'}
+                  </p>
+                  <h2 className="mt-1 text-2xl font-semibold text-slate-900">{section.title}</h2>
+                </div>
+                <div className="px-6 py-6">
+                  {section.type === 'listening' ? (
+                    <ListeningSectionView
+                      section={section}
+                      answers={answers}
+                      onChange={handleChange}
+                      audioControls={audioControls}
+                    />
+                  ) : (
+                    <ReadingSectionView section={section} answers={answers} onChange={handleChange} />
+                  )}
+                </div>
+              </section>
+            ))}
+
+            <div className="rounded-3xl border border-slate-200 bg-white px-6 py-6 shadow-lg">
+              {error && <p className="text-sm font-semibold text-red-600">{error}</p>}
+              <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <div className="text-sm text-slate-600">
+                  <p>
+                    Time remaining for this section: <span className="font-semibold">{formatDuration(phase === 'listening' ? listeningTimeLeft : readingTimeLeft)}</span>
+                  </p>
+                  <p className="mt-1 text-xs text-slate-500">
+                    {phase === 'listening'
+                      ? 'Finish the Listening tasks before moving on. The Reading section will open automatically when time runs out.'
+                      : 'Submit your answers when you are satisfied. The test will submit automatically if time expires.'}
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  onClick={actionHandler}
+                  disabled={submitting}
+                  className="inline-flex items-center justify-center rounded-full bg-sky-600 px-6 py-3 text-sm font-semibold text-white shadow transition hover:bg-sky-500 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {submitting ? 'Submitting…' : actionLabel}
+                </button>
+              </div>
+            </div>
+          </>
+        )}
       </div>
     </div>
   );

--- a/src/lib/supabaseAdmin.ts
+++ b/src/lib/supabaseAdmin.ts
@@ -1,7 +1,91 @@
-import { createClient } from '@supabase/supabase-js';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
 
-export const supabaseAdmin = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY!,
-  { auth: { persistSession: false } }
-);
+type SupabaseEnvKey = 'NEXT_PUBLIC_SUPABASE_URL' | 'SUPABASE_SERVICE_ROLE_KEY';
+
+const REQUIRED_KEYS: SupabaseEnvKey[] = ['NEXT_PUBLIC_SUPABASE_URL', 'SUPABASE_SERVICE_ROLE_KEY'];
+
+let cachedClient: SupabaseClient | null | undefined;
+
+function isServerRuntime(): boolean {
+  return typeof window === 'undefined';
+}
+
+function unquote(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) return '';
+  const startsWithQuote = trimmed.startsWith('"') || trimmed.startsWith("'");
+  const endsWithQuote = trimmed.endsWith('"') || trimmed.endsWith("'");
+  if (startsWithQuote && endsWithQuote && trimmed.length >= 2) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+function hydrateEnvFromLocalFile(): void {
+  if (!isServerRuntime()) return;
+
+  const missingKeys = REQUIRED_KEYS.filter((key) => !process.env[key]);
+  if (missingKeys.length === 0) return;
+
+  const envPath = path.join(process.cwd(), '.env.local');
+  let raw: string;
+
+  try {
+    raw = readFileSync(envPath, 'utf-8');
+  } catch {
+    return;
+  }
+
+  const discovered = new Map<string, string>();
+  for (const line of raw.split(/\r?\n/)) {
+    if (!line || /^\s*#/.test(line)) continue;
+    const separatorIndex = line.indexOf('=');
+    if (separatorIndex === -1) continue;
+    const key = line.slice(0, separatorIndex).trim();
+    if (!key || !REQUIRED_KEYS.includes(key as SupabaseEnvKey)) continue;
+    const rawValue = line.slice(separatorIndex + 1);
+    const value = unquote(rawValue);
+    if (!discovered.has(key)) {
+      discovered.set(key, value);
+    }
+  }
+
+  for (const key of missingKeys) {
+    if (process.env[key]) continue;
+    const value = discovered.get(key);
+    if (typeof value === 'string' && value.length > 0) {
+      process.env[key] = value;
+    }
+  }
+}
+
+function createSupabaseAdmin(): SupabaseClient | null {
+  hydrateEnvFromLocalFile();
+
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!url || !serviceRoleKey) {
+    return null;
+  }
+
+  return createClient(url, serviceRoleKey, { auth: { persistSession: false } });
+}
+
+export function getSupabaseAdmin(): SupabaseClient | null {
+  if (!isServerRuntime()) return null;
+
+  if (typeof cachedClient !== 'undefined') {
+    return cachedClient;
+  }
+
+  cachedClient = createSupabaseAdmin();
+  return cachedClient;
+}
+
+export function hasSupabaseCredentials(): boolean {
+  hydrateEnvFromLocalFile();
+  return Boolean(process.env.NEXT_PUBLIC_SUPABASE_URL && process.env.SUPABASE_SERVICE_ROLE_KEY);
+}


### PR DESCRIPTION
## Summary
- load Supabase credentials from `.env.local` when missing and update API routes to guard when Supabase is unavailable
- fix dynamic API routes to await params for Next.js 15 compliance
- redesign the test runner with listening/reading stages, timers, dark answer text, and a thank you view instead of score details

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc30eb9008832eac02f27500bd4bcc