### PR TITLE
Fix Supabase admin auth and await dynamic params

### DIFF
--- a/src/app/test/[testId]/page.tsx
+++ b/src/app/test/[testId]/page.tsx
@@ -9,8 +9,9 @@ export async function generateStaticParams() {
   return ids.map((testId) => ({ testId }));
 }
 
-export async function generateMetadata({ params }: { params: { testId: string } }): Promise<Metadata> {
-  const test = await getTestDefinition(params.testId);
+export async function generateMetadata({ params }: { params: Promise<{ testId: string }> }): Promise<Metadata> {
+  const { testId } = await params;
+  const test = await getTestDefinition(testId);
   if (!test) {
     return { title: 'IELTS Mock Test' };
   }
@@ -19,8 +20,9 @@ export async function generateMetadata({ params }: { params: { testId: string } 
   };
 }
 
-export default async function TestPage({ params }: { params: { testId: string } }) {
-  const test = await getTestDefinition(params.testId);
+export default async function TestPage({ params }: { params: Promise<{ testId: string }> }) {
+  const { testId } = await params;
+  const test = await getTestDefinition(testId);
   if (!test) {
     notFound();
   }


### PR DESCRIPTION
## Summary
- sanitize Supabase credentials, disable session persistence, and send explicit service role authorization headers so writes use the admin key
- allow recreating the cached Supabase client when credentials become available
- await dynamic route params in the test page metadata and component to satisfy Next.js 15 requirements

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc8a388530832e8ce76dee216d30ee