### PR TITLE
Use async cookies API in submit route

### DIFF
--- a/src/app/api/tests/[testId]/submit/route.ts
+++ b/src/app/api/tests/[testId]/submit/route.ts
@@ -99,9 +99,11 @@ export async function POST(
   }
   const answers = rawAnswers as Record<string, unknown>;
 
+  const cookieStore = await cookies();
+  const sessionToken = cookieStore.get('session_token')?.value ?? null;
+
   const supabaseConfigured = hasSupabaseCredentials();
   const supabase = getSupabaseAdmin();
-  const sessionToken = cookies().get('session_token')?.value ?? null;
 
   if (supabaseConfigured && !supabase) {
     return NextResponse.json({ error: 'Supabase is configured but unavailable.' }, { status: 503 });


### PR DESCRIPTION
## Summary
- obtain the cookie store via the async cookies API before reading the session token
- preserve the remainder of the submit route logic

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ccb4363554832eb7e5527662befa9e