### PR TITLE
Add writing CTA after submissions and persist interest

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -9,29 +9,47 @@ export default function LoginPage() {
 
   async function handleLogin(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
-    setLoading(true); setError('');
+    setLoading(true);
+    setError('');
     const token = (e.currentTarget.elements.namedItem('token') as HTMLInputElement).value;
-    const res = await fetch('/api/session', { method: 'POST', body: JSON.stringify({ token }), headers: { 'Content-Type': 'application/json' } });
+    const res = await fetch('/api/session', {
+      method: 'POST',
+      body: JSON.stringify({ token }),
+      headers: { 'Content-Type': 'application/json' },
+    });
     if (res.ok) window.location.href = DEFAULT_TEST_PATH;
-    else { const data = await res.json(); setError(data.error || 'Login failed'); }
+    else {
+      const data = await res.json();
+      setError(data.error || 'Login failed');
+    }
     setLoading(false);
   }
 
   return (
-    <main className="mx-auto max-w-md p-10">
-      <h1 className="mb-2 text-2xl font-bold text-slate-900">Login to the IELTS Try Out</h1>
-      <p className="mb-6 text-sm text-slate-600">
-        Enter your token to access the Listening & Reading try out. Writing & Speaking modules are being prepared and will be
-        announced by email soon.
-      </p>
-      <form onSubmit={handleLogin} className="flex flex-col gap-4">
-        <input name="token" placeholder="Enter token" className="rounded border border-slate-300 p-3 text-sm" required />
-        <button disabled={loading} className="rounded bg-green-600 px-4 py-2 text-sm font-semibold text-white disabled:opacity-70">
-          {loading ? 'Loading...' : 'Login'}
-        </button>
-      </form>
-      <p className="mt-3 text-xs text-slate-500">Scoring will be delivered by email.</p>
-      {error && <p className="mt-2 text-sm text-red-600">{error}</p>}
+    <main className="flex min-h-screen items-center justify-center bg-slate-950 px-6 py-16 text-white">
+      <div className="w-full max-w-md rounded-3xl border border-white/10 bg-white/5 p-10 shadow-2xl shadow-slate-950/40 backdrop-blur">
+        <h1 className="mb-2 text-2xl font-bold text-white">Login to the IELTS Try Out</h1>
+        <p className="mb-6 text-sm text-slate-100/80">
+          Enter your token to access the Listening & Reading try out. Writing & Speaking modules are being prepared and will be
+          announced by email soon.
+        </p>
+        <form onSubmit={handleLogin} className="flex flex-col gap-4">
+          <input
+            name="token"
+            placeholder="Enter token"
+            className="rounded border border-white/20 bg-white/95 p-3 text-sm text-slate-900 shadow-sm placeholder:text-slate-500 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            required
+          />
+          <button
+            disabled={loading}
+            className="rounded bg-emerald-500 px-4 py-2 text-sm font-semibold text-white shadow-lg shadow-emerald-500/30 transition hover:bg-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-300 focus:ring-offset-2 focus:ring-offset-slate-950 disabled:cursor-not-allowed disabled:opacity-70"
+          >
+            {loading ? 'Loading...' : 'Login'}
+          </button>
+        </form>
+        <p className="mt-3 text-xs text-slate-100/70">Scoring will be delivered by email.</p>
+        {error && <p className="mt-2 text-sm text-rose-300">{error}</p>}
+      </div>
     </main>
   );
 }

--- a/src/components/test/TestRunner.tsx
+++ b/src/components/test/TestRunner.tsx
@@ -11,6 +11,7 @@ import type {
   TestDefinition,
 } from '@/lib/tests';
 
+import InterestForm from '@/components/InterestForm';
 import { MarkdownText } from './MarkdownText';
 
 type AnswerValue = string | number | null;
@@ -665,27 +666,59 @@ export function TestRunner({ test }: { test: TestDefinition }) {
         </header>
 
         {showThankYou ? (
-          <div className="rounded-3xl border border-slate-200 bg-white p-8 shadow-lg">
-            <h2 className="text-2xl font-semibold text-slate-900">Thank you for your submission!</h2>
-            <p className="mt-3 text-sm text-slate-600">
-              Your answers have been recorded. Our team will review them and share the result via email.
-            </p>
-            {submissionInfo?.submissionId && (
-              <p className="mt-4 text-sm text-slate-600">
-                Confirmation ID: <span className="font-mono text-slate-900">{submissionInfo.submissionId}</span>
+          <>
+            <div className="rounded-3xl border border-slate-200 bg-white p-8 shadow-lg">
+              <h2 className="text-2xl font-semibold text-slate-900">Thank you for your submission!</h2>
+              <p className="mt-3 text-sm text-slate-600">
+                Your answers have been recorded. Our team will review them and share the result via email.
               </p>
-            )}
-            {submissionInfo?.warnings?.length ? (
-              <div className="mt-6 rounded-2xl border border-amber-200 bg-amber-50 p-6 text-sm text-amber-700 shadow-sm">
-                <h3 className="text-base font-semibold">Submission notes</h3>
-                <ul className="mt-3 space-y-2 list-disc pl-5">
-                  {submissionInfo.warnings.map((warning) => (
-                    <li key={warning}>{warning}</li>
-                  ))}
-                </ul>
+              {submissionInfo?.submissionId && (
+                <p className="mt-4 text-sm text-slate-600">
+                  Confirmation ID: <span className="font-mono text-slate-900">{submissionInfo.submissionId}</span>
+                </p>
+              )}
+              {submissionInfo?.warnings?.length ? (
+                <div className="mt-6 rounded-2xl border border-amber-200 bg-amber-50 p-6 text-sm text-amber-700 shadow-sm">
+                  <h3 className="text-base font-semibold">Submission notes</h3>
+                  <ul className="mt-3 space-y-2 list-disc pl-5">
+                    {submissionInfo.warnings.map((warning) => (
+                      <li key={warning}>{warning}</li>
+                    ))}
+                  </ul>
+                </div>
+              ) : null}
+            </div>
+            <section className="rounded-3xl bg-slate-900 p-8 text-white shadow-xl shadow-slate-950/40">
+              <div className="flex flex-col gap-8 lg:flex-row lg:items-center">
+                <div className="lg:w-1/2">
+                  <span className="inline-flex items-center gap-2 rounded-full bg-white/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-sky-200 ring-1 ring-white/20">
+                    Coming soon
+                  </span>
+                  <h3 className="mt-6 text-2xl font-semibold text-white sm:text-3xl">Writing & Speaking Try Out is in development</h3>
+                  <p className="mt-4 text-sm text-slate-200">
+                    We are preparing interactive Writing and Speaking tasks so you can complete the full IELTS experience. Join the early interest list and we will contact you as soon as the new try out launches.
+                  </p>
+                  <p className="mt-4 text-xs text-slate-300">All follow-ups happen through email—no WhatsApp numbers required.</p>
+                </div>
+                <div className="lg:w-1/2">
+                  <div className="rounded-3xl bg-white p-6 text-slate-900 shadow-2xl shadow-slate-950/20 ring-1 ring-slate-200">
+                    <h4 className="text-lg font-semibold">Want to be first in line?</h4>
+                    <p className="mt-2 text-sm text-slate-600">
+                      Leave your name and email so our team can contact you once the Writing & Speaking try out is live.
+                    </p>
+                    <InterestForm
+                      className="mt-6"
+                      inputClassName="bg-slate-50"
+                      buttonClassName="bg-emerald-500 hover:bg-emerald-400 focus:ring-emerald-300"
+                    />
+                    <p className="mt-4 text-xs text-slate-500">
+                      We will only use your email to share launch updates for the Writing & Speaking try out.
+                    </p>
+                  </div>
+                </div>
               </div>
-            ) : null}
-          </div>
+            </section>
+          </>
         ) : (
           <>
             {visibleSections.map((section) => (


### PR DESCRIPTION
## Summary
- restyle the token login screen with a dark backdrop and white typography so content stays legible
- surface the Writing & Speaking "coming soon" call-to-action after learners submit their test to collect more interest
- persist interest submissions in the new `writing_speaking_interest` table before sending the notification email

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ccd9be3180832ea71ad0b8a7ccc2db