### PR TITLE
Adjust asset route handler for Next.js 15 request context

### DIFF
--- a/src/app/api/tests/[testId]/assets/[...assetPath]/route.ts
+++ b/src/app/api/tests/[testId]/assets/[...assetPath]/route.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
 import { promises as fs } from 'node:fs';
+import { NextRequest } from 'next/server';
 
 export const runtime = 'nodejs';
 
@@ -36,10 +37,10 @@ function getMimeType(ext: string): string {
 }
 
 export async function GET(
-  _request: Request,
-  { params }: { params: { testId: string; assetPath: string[] } }
+  request: NextRequest,
+  context: { params: Promise<{ testId: string; assetPath: string[] }> }
 ): Promise<Response> {
-  const { testId, assetPath } = params;
+  const { testId, assetPath } = await context.params;
   if (!isSafeTestId(testId) || !Array.isArray(assetPath) || assetPath.length === 0) {
     return new Response('Not found', { status: 404 });
   }


### PR DESCRIPTION
## Summary
- import `NextRequest` and update the asset route handler signature to match Next.js 15 expectations
- await the async `params` context before using the test and asset identifiers

## Testing
- pnpm run build *(fails: Next.js cannot download Google Fonts in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd1f2a23fc832e909ef945864c322f