### PR TITLE
Fix asset API response body type

### DIFF
--- a/src/app/api/tests/[testId]/assets/[...assetPath]/route.ts
+++ b/src/app/api/tests/[testId]/assets/[...assetPath]/route.ts
@@ -55,13 +55,8 @@ export async function GET(
   try {
     const file = await fs.readFile(resolvedPath);
     const contentType = getMimeType(path.extname(resolvedPath).toLowerCase());
-    const body = new Uint8Array(
-      file.buffer,
-      file.byteOffset,
-      file.byteLength
-    );
 
-    return new Response(body, {
+    return new Response(file, {
       headers: {
         'Content-Type': contentType,
         'Cache-Control': 'public, max-age=31536000, immutable',


### PR DESCRIPTION
## Summary
- return the file buffer directly from the asset API route so the Response initializer receives a supported body type

## Testing
- pnpm run build *(fails: Next.js cannot download Google Fonts in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd246081b4832eb75efe8d34d303ba