### PR TITLE
Fix asset response body typing

### DIFF
--- a/src/app/api/tests/[testId]/assets/[...assetPath]/route.ts
+++ b/src/app/api/tests/[testId]/assets/[...assetPath]/route.ts
@@ -55,10 +55,10 @@ export async function GET(
   try {
     const file = await fs.readFile(resolvedPath);
     const contentType = getMimeType(path.extname(resolvedPath).toLowerCase());
-    const arrayBuffer = file.buffer.slice(
-      file.byteOffset,
-      file.byteOffset + file.byteLength
-    ) as ArrayBuffer;
+    const arrayBuffer = new ArrayBuffer(file.byteLength);
+    new Uint8Array(arrayBuffer).set(
+      new Uint8Array(file.buffer, file.byteOffset, file.byteLength)
+    );
 
     return new Response(arrayBuffer, {
       headers: {


### PR DESCRIPTION
## Summary
- copy file buffers into a dedicated ArrayBuffer before returning the API response so the body matches the `Response` type constraints

## Testing
- CI=1 pnpm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd31b53f24832e8a4474ce1a1b6530