### PR TITLE
Fix interest notifications and add analytics example display

### DIFF
--- a/init_ielts_pack.sh
+++ b/init_ielts_pack.sh
@@ -56,6 +56,7 @@ cat > "${PACK_ROOT}/test.json" << 'EOF'
       "title": "Listening Section 1 (Q1–10)",
       "audio_src": "assets/listening/track_1.mp3",
       "instructions_md": "Complete the notes. Write **ONE WORD AND/OR A NUMBER** for each answer.",
+      "example_md": "",
       "questions": [
         { "q_id": "L1-Q1",  "q_type": "short_text", "expected": "one_word_or_number", "prompt_md": "Room and cost – the **_____ Room** – seats 100" },
         { "q_id": "L1-Q2",  "q_type": "short_text", "expected": "currency_number",     "prompt_md": "Cost of Main Hall for Saturday evening: £ **_____**" },

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@supabase/supabase-js": "^2.57.4",
         "@types/nodemailer": "^7.0.1",
+        "@vercel/analytics": "^1.5.0",
         "next": "15.5.3",
         "nodemailer": "^7.0.6",
         "react": "19.1.0",
@@ -3232,6 +3233,44 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.5.0.tgz",
+      "integrity": "sha512-MYsBzfPki4gthY5HnYN7jgInhAZ7Ac1cYDoRWFomwGHWEX7odTEzbtg9kf/QSo7XEsEAqlQugA6gJ2WS2DEa3g==",
+      "license": "MPL-2.0",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/acorn": {
       "version": "8.15.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@supabase/supabase-js": "^2.57.4",
     "@types/nodemailer": "^7.0.1",
+    "@vercel/analytics": "^1.5.0",
     "next": "15.5.3",
     "nodemailer": "^7.0.6",
     "react": "19.1.0",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { Analytics } from "@vercel/analytics/next";
 import "./globals.css";
 
 const geistSans = {
@@ -25,6 +26,7 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         {children}
+        <Analytics />
       </body>
     </html>
   );

--- a/src/components/test/TestRunner.tsx
+++ b/src/components/test/TestRunner.tsx
@@ -370,6 +370,11 @@ function ListeningSectionView({ section, answers, onChange, audioControls }: Sec
       />
       <AssetDisplay assets={section.assets} sectionTitle={section.title} />
       <div className="space-y-4">
+        {section.exampleMd && (
+          <div className="rounded-xl border border-slate-200 bg-slate-50 px-4 py-3">
+            <MarkdownText content={section.exampleMd} className="space-y-1 text-sm font-medium text-slate-700" />
+          </div>
+        )}
         {section.questions.map((question) => (
           <QuestionCard
             key={question.qId}

--- a/src/lib/tests.ts
+++ b/src/lib/tests.ts
@@ -24,6 +24,7 @@ export interface ListeningSectionDefinition {
   type: 'listening';
   title: string;
   instructionsMd?: string;
+  exampleMd?: string;
   audioSrc?: string;
   questions: NormalizedQuestion[];
   assets?: Record<string, string>;
@@ -34,6 +35,7 @@ export interface ReadingSectionDefinition {
   type: 'reading';
   title: string;
   instructionsMd?: string;
+  exampleMd?: string;
   passageMd?: string;
   layout?: { columns?: number; readingOrder?: string };
   questions: NormalizedQuestion[];
@@ -80,6 +82,7 @@ interface RawSection {
   type: 'listening' | 'reading';
   title: string;
   instructions_md?: string;
+  example_md?: string;
   audio_src?: string;
   passage_src_md?: string;
   layout?: { columns?: number; reading_order?: string };
@@ -178,6 +181,7 @@ export async function getTestDefinition(testId: string): Promise<TestDefinition 
         sectionId: section.section_id,
         title: section.title,
         instructionsMd: section.instructions_md,
+        exampleMd: section.example_md,
         questions: section.questions.map(mapQuestion),
         assets: mapAssets(manifest.test_id, section.assets),
       };

--- a/tests/IELTS_Test_1/test.json
+++ b/tests/IELTS_Test_1/test.json
@@ -17,6 +17,7 @@
       "title": "Listening Section 1 (Q1–10)",
       "audio_src": "assets/listening/track_1.mp3",
       "instructions_md": "Complete the notes. Write **ONE WORD AND/OR A NUMBER** for each answer.",
+      "example_md": "**Example**\nThe Main Hall - seats ..200...",
       "questions": [
         { "q_id": "L1-Q1",  "q_type": "short_text", "expected": "one_word_or_number", "prompt_md": "Room and cost – the **_____ Room** – seats 100" },
         { "q_id": "L1-Q2",  "q_type": "short_text", "expected": "currency_number",     "prompt_md": "Cost of Main Hall for Saturday evening: £ **_____**" },


### PR DESCRIPTION
## Summary
- support MAIL_FROM when resolving the sender for transactional and interest notification emails
- remove the local CSV export from the test submission API in favour of remote persistence only
- add Vercel Analytics and surface listening section example text in the UI and manifest

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd469e951c832eab5facc3645ca4c5