### PR TITLE
Fix interest notifications and add analytics example display

### DIFF
--- a/init_ielts_pack.sh
+++ b/init_ielts_pack.sh
@@ -56,6 +56,7 @@ cat > "${PACK_ROOT}/test.json" << 'EOF'
       "title": "Listening Section 1 (Q1–10)",
       "audio_src": "assets/listening/track_1.mp3",
       "instructions_md": "Complete the notes. Write **ONE WORD AND/OR A NUMBER** for each answer.",
+      "example_md": "",
       "questions": [
         { "q_id": "L1-Q1",  "q_type": "short_text", "expected": "one_word_or_number", "prompt_md": "Room and cost – the **_____ Room** – seats 100" },
         { "q_id": "L1-Q2",  "q_type": "short_text", "expected": "currency_number",     "prompt_md": "Cost of Main Hall for Saturday evening: £ **_____**" },

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@supabase/supabase-js": "^2.57.4",
         "@types/nodemailer": "^7.0.1",
+        "@vercel/analytics": "^1.5.0",
         "next": "15.5.3",
         "nodemailer": "^7.0.6",
         "react": "19.1.0",
@@ -3232,6 +3233,44 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.5.0.tgz",
+      "integrity": "sha512-MYsBzfPki4gthY5HnYN7jgInhAZ7Ac1cYDoRWFomwGHWEX7odTEzbtg9kf/QSo7XEsEAqlQugA6gJ2WS2DEa3g==",
+      "license": "MPL-2.0",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/acorn": {
       "version": "8.15.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@supabase/supabase-js": "^2.57.4",
     "@types/nodemailer": "^7.0.1",
+    "@vercel/analytics": "^1.5.0",
     "next": "15.5.3",
     "nodemailer": "^7.0.6",
     "react": "19.1.0",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { Analytics } from "@vercel/analytics/next";
 import "./globals.css";
 
 const geistSans = {
@@ -25,6 +26,7 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         {children}
+        <Analytics />
       </body>
     </html>
   );

--- a/src/components/test/TestRunner.tsx
+++ b/src/components/test/TestRunner.tsx
@@ -37,6 +37,38 @@ type QuestionCardProps = {
   onChange: (value: AnswerValue) => void;
 };
 
+function ExampleCard({ content }: { content: string }) {
+  const normalized = content.replace(/\r\n/g, '\n').trim();
+
+  if (!normalized) {
+    return (
+      <div className="rounded-xl border border-amber-200 bg-amber-50 px-4 py-4 shadow-sm">
+        <p className="text-xs font-semibold uppercase tracking-wide text-amber-700">Example</p>
+      </div>
+    );
+  }
+
+  const [firstLine, ...restLines] = normalized.split('\n');
+  const rawLabel = firstLine.trim();
+  const boldMatch = rawLabel.match(/^\*\*(.+)\*\*$/) ?? rawLabel.match(/^__(.+)__$/);
+  const italicMatch = rawLabel.match(/^\*(.+)\*$/) ?? rawLabel.match(/^_(.+)_$/);
+  const strippedLabel = boldMatch?.[1] ?? italicMatch?.[1] ?? rawLabel;
+  const labelCandidate = strippedLabel.replace(/:$/, '').trim();
+  const matchesExample = /^example$/i.test(labelCandidate);
+  const label = matchesExample && labelCandidate ? labelCandidate : 'Example';
+  const bodyCandidate = matchesExample ? restLines.join('\n').trim() : normalized;
+  const body = bodyCandidate.length > 0 ? bodyCandidate : matchesExample ? '' : normalized;
+
+  return (
+    <div className="rounded-xl border border-amber-200 bg-amber-50 px-4 py-4 shadow-sm">
+      <p className="text-xs font-semibold uppercase tracking-wide text-amber-700">{label}</p>
+      {body ? (
+        <MarkdownText content={body} className="mt-2 space-y-1 text-sm text-amber-900" />
+      ) : null}
+    </div>
+  );
+}
+
 type AudioPlayerProps = {
   src?: string;
   allowSeek?: boolean;
@@ -370,6 +402,7 @@ function ListeningSectionView({ section, answers, onChange, audioControls }: Sec
       />
       <AssetDisplay assets={section.assets} sectionTitle={section.title} />
       <div className="space-y-4">
+        {section.exampleMd ? <ExampleCard content={section.exampleMd} /> : null}
         {section.questions.map((question) => (
           <QuestionCard
             key={question.qId}
@@ -678,16 +711,6 @@ export function TestRunner({ test }: { test: TestDefinition }) {
                   Confirmation ID: <span className="font-mono text-slate-900">{submissionInfo.submissionId}</span>
                 </p>
               )}
-              {submissionInfo?.warnings?.length ? (
-                <div className="mt-6 rounded-2xl border border-amber-200 bg-amber-50 p-6 text-sm text-amber-700 shadow-sm">
-                  <h3 className="text-base font-semibold">Submission notes</h3>
-                  <ul className="mt-3 space-y-2 list-disc pl-5">
-                    {submissionInfo.warnings.map((warning) => (
-                      <li key={warning}>{warning}</li>
-                    ))}
-                  </ul>
-                </div>
-              ) : null}
             </div>
             <section className="rounded-3xl bg-slate-900 p-8 text-white shadow-xl shadow-slate-950/40">
               <div className="flex flex-col gap-8 lg:flex-row lg:items-center">

--- a/src/lib/tests.ts
+++ b/src/lib/tests.ts
@@ -24,6 +24,7 @@ export interface ListeningSectionDefinition {
   type: 'listening';
   title: string;
   instructionsMd?: string;
+  exampleMd?: string;
   audioSrc?: string;
   questions: NormalizedQuestion[];
   assets?: Record<string, string>;
@@ -34,6 +35,7 @@ export interface ReadingSectionDefinition {
   type: 'reading';
   title: string;
   instructionsMd?: string;
+  exampleMd?: string;
   passageMd?: string;
   layout?: { columns?: number; readingOrder?: string };
   questions: NormalizedQuestion[];
@@ -80,6 +82,7 @@ interface RawSection {
   type: 'listening' | 'reading';
   title: string;
   instructions_md?: string;
+  example_md?: string;
   audio_src?: string;
   passage_src_md?: string;
   layout?: { columns?: number; reading_order?: string };
@@ -178,6 +181,7 @@ export async function getTestDefinition(testId: string): Promise<TestDefinition 
         sectionId: section.section_id,
         title: section.title,
         instructionsMd: section.instructions_md,
+        exampleMd: section.example_md,
         questions: section.questions.map(mapQuestion),
         assets: mapAssets(manifest.test_id, section.assets),
       };

--- a/tests/IELTS_Test_1/test.json
+++ b/tests/IELTS_Test_1/test.json
@@ -17,6 +17,7 @@
       "title": "Listening Section 1 (Q1–10)",
       "audio_src": "assets/listening/track_1.mp3",
       "instructions_md": "Complete the notes. Write **ONE WORD AND/OR A NUMBER** for each answer.",
+      "example_md": "**Example**\nThe Main Hall - seats ..200...",
       "questions": [
         { "q_id": "L1-Q1",  "q_type": "short_text", "expected": "one_word_or_number", "prompt_md": "Room and cost – the **_____ Room** – seats 100" },
         { "q_id": "L1-Q2",  "q_type": "short_text", "expected": "currency_number",     "prompt_md": "Cost of Main Hall for Saturday evening: £ **_____**" },


### PR DESCRIPTION
## Summary
- support MAIL_FROM when resolving the sender for transactional and interest notification emails
- remove the local CSV export from the test submission API in favour of remote persistence only
- add Vercel Analytics and surface the listening section example in a dedicated callout before the first question
- drop the submission warning panel from the confirmation screen

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd469e951c832eab5facc3645ca4c5